### PR TITLE
Adding windows versions of build and run scripts

### DIFF
--- a/windows/build_windows.bat
+++ b/windows/build_windows.bat
@@ -1,0 +1,50 @@
+@echo OFF
+
+REM Move up one directory to top level
+cd ..
+
+REM set the top directory
+SET TOP=%cd%
+
+REM Create our lib directory
+mkdir %TOP%\lib\jvm
+
+REM download jdk 11
+if exist %TOP%\lib\jvm\jdk-11.0.2 goto JVMEXISTS
+curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip --output %TOP%\lib\jvm\openjdk-11.0.2_windows-x64_bin.zip
+cd %TOP%\lib\jvm
+tar -xf openjdk-11.0.2_windows-x64_bin.zip
+rm openjdk-11.0.2_windows-x64_bin.zip
+:JVMEXISTS
+
+REM download maven
+if exist %TOP%\lib\apache-maven-3.6.0 goto MVNEXISTS
+curl https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.zip --output %TOP%\lib\apache-maven-3.6.0-bin.zip
+cd %TOP%\lib
+tar -xf apache-maven-3.6.0-bin.zip
+rm apache-maven-3.6.0-bin.zip
+:MVNEXISTS
+
+REM install phoebus
+if exist %TOP%\lib\phoebus goto PHOEBUSEXISTS
+cd %TOP%\lib
+git clone https://github.com/shroffk/phoebus.git
+:PHOEBUSEXISTS
+cd %TOP%\lib\phoebus
+git pull
+
+REM set the java and maven env variables
+
+SET JAVA_HOME=%TOP%\lib\jvm\jdk-11.0.2
+SET PATH=%JAVA_HOME%\bin;%PATH%
+
+SET MVN_HOME=%TOP%\lib\apache-maven-3.6.0
+SET PATH=%MVN_HOME%\bin;%PATH%
+
+REM build phoebus
+cd %TOP%\lib\phoebus
+mvn clean install --settings=%TOP%\settings.xml -DskipTests=true
+
+REM build nsls2 product
+cd %TOP%\products
+mvn clean install --settings=%TOP%\settings.xml -DskipTests=true

--- a/windows/run-phoebus.bat
+++ b/windows/run-phoebus.bat
@@ -1,0 +1,25 @@
+@echo OFF
+
+cd ..
+
+SET TOP=%cd%
+
+SET JAVA_HOME=%TOP%\lib\jvm\jdk-11.0.2
+SET PATH=%JAVA_HOME%\bin;%PATH%
+
+echo %TOP%
+SET PHOEBUS_VERSION="4.6.2-SNAPSHOT"
+
+REM figure out the path to the product jar
+PHOEBUS_JAR=%TOP%\products\nsls2-accl\target\nsls2-accl-product-%PHOEBUS_VERSION%.jar
+
+
+SET JDK_JAVA_OPTIONS=" -DCA_DISABLE_REPEATER=true"
+SET JDK_JAVA_OPTIONS="%JDK_JAVA_OPTIONS% -Dnashorn.args=--no-deprecation-warning"
+SET JDK_JAVA_OPTIONS="%JDK_JAVA_OPTIONS% -Djdk.gtk.verbose=false -Djdk.gtk.version=2 -Dprism.forceGPU=true"
+REM SET JDK_JAVA_OPTIONS="%JDK_JAVA_OPTIONS% -Dlogback.configurationFile=\home\train\epics-tools\setup\settings\logback.xml"
+SET JDK_JAVA_OPTIONS="%JDK_JAVA_OPTIONS% -Dorg.csstudio.javafx.rtplot.update_counter=false"
+
+echo %JDK_JAVA_OPTIONS%
+
+java -jar %PHOEBUS_JAR% -settings %PHOEBUS_CONFIG% -logging %TOP%\config\logging.properties $OPT "$@" &


### PR DESCRIPTION
I think it would be useful for testing on windows to have windows versions of the scripts included here. For now they don't seem to fully work yet, I get a bunch of maven non-resolvable import errors, not entirely sure what those are:

```
[INFO] Scanning for projects...
Downloading from sonatype-nexus-snapshots: https://oss.sonatype.org/content/repositories/snapshots/org/springframework/boot/spring-boot-dependencies/2.1.5.RELEASE/spring-boot-dependencies-2.1.5.RELEASE.pom
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.1.5.RELEASE/spring-boot-dependencies-2.1.5.RELEASE.pom
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Non-resolvable import POM: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:2.1.5.RELEASE from/to sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots): No such host is known (proxy) @ org.phoebus:service-alarm-logger:[unknown-version], E:\BNL\nsls2-phoebus\lib\phoebus\services\alarm-logger\pom.xml, line 17, column 19
[ERROR] 'dependencies.dependency.version' for org.springframework.boot:spring-boot-starter:jar is missing. @ org.phoebus:service-alarm-logger:[unknown-version], E:\BNL\nsls2-phoebus\lib\phoebus\services\alarm-logger\pom.xml, line 29, column 17
...
```